### PR TITLE
Bump pillow from 6.2.0 to 6.2.2

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,6 +4,6 @@ flask==1.0.2
 itsdangerous==1.1.0
 jinja2==2.10.3
 markupsafe==1.1.1
-pillow==6.2.0
+pillow==6.2.2
 pytesseract==0.2.6
 werkzeug==0.16.0


### PR DESCRIPTION
#### What does this PR do?

Updates pillow to 6.2.2.

#### Description of Task to be completed?

In MacOS 10.15.6 pillow 6.2.0 can not be installed. But 6.2.2 version [installs normally](https://github.com/python-pillow/Pillow/issues/4242#issuecomment-594047667)

#### How should this be manually tested?

1. Load to MacOS 10.15.6 
2. Try to install pillow 6.2.0
3. [Similar error](https://github.com/python-pillow/Pillow/issues/4242) will be displayed
4. Try to install pillow 6.2.2 - everything is ok

I tested it on my machine - project's code is working normally.